### PR TITLE
Adds BroadcastReceiver for toggling

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
   ~ Simiasque
   ~ Copyright (C) 2015 Orange
@@ -6,23 +7,35 @@
   ~ This Source Code Form is subject to the terms of the Mozilla Public
   ~ License, v. 2.0. If a copy of the MPL was not distributed with this
   ~ file, You can obtain one at http://mozilla.org/MPL/2.0/.
-  -->
-
+-->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.thisisafactory.simiasque">
+    package="org.thisisafactory.simiasque" >
 
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:icon="@mipmap/ic_launcher" android:theme="@style/AppTheme">
-
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:theme="@style/AppTheme" >
         <activity android:name=".MyActivity_" >
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
         </activity>
-        <service android:name=".ViewService_"/>
+
+        <service android:name=".ViewService_" />
+
+        <receiver
+            android:name=".SimiasqueReceiver"
+            android:enabled="true"
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="org.thisisafactory.simiasque.SET_OVERLAY" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/app/src/main/java/org/thisisafactory/simiasque/SimiasqueReceiver.java
+++ b/app/src/main/java/org/thisisafactory/simiasque/SimiasqueReceiver.java
@@ -1,0 +1,30 @@
+package org.thisisafactory.simiasque;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+/**
+ * Broadcast receive for toggling Simiasque.
+ */
+public class SimiasqueReceiver extends BroadcastReceiver {
+
+    public static final String EXTRA_ENABLE = "enable";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if(intent.getAction().equals("org.thisisafactory.simiasque.SET_OVERLAY")) {
+            if (intent.hasExtra(EXTRA_ENABLE)) {
+                boolean enable = intent.getBooleanExtra(EXTRA_ENABLE, false);
+                if (enable) {
+                    ViewService_.intent(context).showMask().start();
+                } else {
+                    ViewService_.intent(context).hideMask().start();
+                }
+            } else {
+                Log.i("Simiasque", "Missing EXTRA_ENABLE in broadcast");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds a BroadcastReceiver listening for `org.thisisafactory.simiasque.SET_OVERLAY` with a boolean extra `enabled`, which allows for toggling using adb shell or other apps.
